### PR TITLE
Fix package

### DIFF
--- a/kaomoji.el
+++ b/kaomoji.el
@@ -2,7 +2,7 @@
 
 ;; Author: Ono Hiroko <azazabc123@gmail.com>
 ;; Keywords: tools, fun
-;; Package-Requires: ((emacs "24.3") (helm "1.9.1"))
+;; Package-Requires: ((emacs "24.3") (helm-core "1.9.1"))
 ;; X-URL: https://github.com/kuanyui/kaomoji.el
 ;; Version: {{VERSION}}
 

--- a/kaomoji.el
+++ b/kaomoji.el
@@ -44,7 +44,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'helm)
 (require 'kaomoji-data)
 
@@ -89,7 +89,7 @@ align & format the them as ((DISPLAY . REAL-KAOMOJI) ...)"
 
 (defun kaomoji-internal-get-candidates (pattern)
   "Return ((MATCHED-STRING . KAOMOJI) ...)"
-  (remove-if
+  (cl-remove-if
    #'null
    (mapcar (lambda (row)
              (let ((matched (cl-member pattern (car row)
@@ -113,9 +113,9 @@ align & format the them as ((DISPLAY . REAL-KAOMOJI) ...)"
 
 (defun kaomoji-matched-pattern? (user-input)
   "See variable `kaomoji-patterns-inserted-along-with'"
-  (some (lambda (pattern)
-          (string-match pattern user-input))
-        kaomoji-patterns-inserted-along-with))
+  (cl-some (lambda (pattern)
+             (string-match pattern user-input))
+           kaomoji-patterns-inserted-along-with))
 
 (defun kaomoji-process-the-string-to-insert (user-input kaomoji-string)
   "Check if should concatenate USER-INPUT to KAOMOJI, then return


### PR DESCRIPTION
- Use cl-lib functions instead of cl.el for suppressing byte-compile warning
- Require helm-core instead of helm, this package uses only helm-core feature
